### PR TITLE
refactor: replace ad-hoc dispatcher with case/esac and usage()

### DIFF
--- a/pimake
+++ b/pimake
@@ -1,12 +1,33 @@
 #!/bin/bash
 
-if [ -f "script/$1.sh" ]; then
-	command=$1
-	shift
-	./script/$command.sh $@
-else
-	echo \# command $1 not recognised
-	exit 1
-fi
+PIMAKE_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-exit 0
+usage() {
+    echo "Usage: pimake <command> [args]"
+    echo ""
+    echo "Commands:"
+    echo "  init     Initialize workspace directories"
+    echo "  fetch    Download and verify image"
+    echo "  unpack   Extract image archive"
+    echo "  build    Mount and configure image (requires sudo)"
+    echo "  pack     Recompress image"
+    echo "  burn     Flash image to disk"
+    echo "  rip      Extract image from existing disk"
+    echo "  clean    Remove build artifacts (--fresh to reset all)"
+}
+
+case "$1" in
+    init|fetch|unpack|build|pack|burn|rip|clean)
+        command=$1
+        shift
+        "$PIMAKE_DIR/script/$command.sh" "$@"
+        ;;
+    -h|--help|"")
+        usage
+        ;;
+    *)
+        echo "pimake: unknown command '$1'" >&2
+        echo "Run 'pimake --help' for usage." >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Closing — scope was too narrow. Will be redone as part of a combined PR covering case/esac + `source pimake.local` + `common.sh` consolidation, per #1.