### PR TITLE
refactor: calculate partition offsets dynamically via losetup

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -11,10 +11,16 @@ header "$0"
 
 check_user root
 
+cleanup() {
+    [ -n "$LODEV" ] && losetup -d "$LODEV"
+}
+trap cleanup EXIT
+
 wpa_conf=$target_root/etc/wpa_supplicant/wpa_supplicant.conf
 wvdial_conf=$target_root/etc/wvdial.conf
 
-# fdisk -l $image
+LODEV=$(losetup -fP --show "$image")
+check_error
 
 mount_vfat
 check_error

--- a/script/build.sh
+++ b/script/build.sh
@@ -12,6 +12,7 @@ header "$0"
 check_user root
 
 cleanup() {
+    # shellcheck disable=SC2317
     [ -n "$LODEV" ] && losetup -d "$LODEV"
 }
 trap cleanup EXIT

--- a/script/common/ext4.sh
+++ b/script/common/ext4.sh
@@ -4,17 +4,15 @@ source script/common/common.sh
 #
 # handle ext4 partition mounting
 #
-## need to get offsets from index.conf
-
 function mount_ext4() {
     msg "mount $mount/ext4"
-    mkdir -p $mount/ext4 272629760
-    mount -o loop,offset=272629760 -t ext4 $image $mount/ext4
+    mkdir -p "$mount/ext4"
+    mount -t ext4 "${LODEV}p2" "$mount/ext4"
 }
 
 function unmount_ext4() {
     msg "unmount $mount/ext4"
-    umount -l $mount/ext4
+    umount -l "$mount/ext4"
     sleep 2
-    rm -rf $mount/ext4
+    rm -rf "$mount/ext4"
 }

--- a/script/common/vfat.sh
+++ b/script/common/vfat.sh
@@ -4,16 +4,15 @@ source script/common/common.sh
 #
 # handle vfat partition mounting
 #
-## need to get offsets from index.conf
 function mount_vfat() {
     msg "mount $mount/vfat"
-    mkdir -p $mount/vfat
-    mount -o loop,offset=4194304 -t vfat $image $mount/vfat
+    mkdir -p "$mount/vfat"
+    mount -t vfat "${LODEV}p1" "$mount/vfat"
 }
 
 function unmount_vfat() {
     msg "unmount $mount/vfat"
-    umount -l $mount/vfat
+    umount -l "$mount/vfat"
     sleep 2
-    rm -rf $mount/vfat
+    rm -rf "$mount/vfat"
 }


### PR DESCRIPTION
Closes #1 (item 2)

Replaces hardcoded byte offsets in `vfat.sh` and `ext4.sh` that were specific to the Feb 2020 Raspbian Buster image (vfat: 4194304, ext4: 272629760). Any other image version or distro would mount at the wrong location. 

The # fdisk -l $image comment in build.sh showed this was already on the radar.


`build.sh` - attaches the image to a loop device at startup with `losetup -fP --show`, which finds the next free device and scans the partition table, giving `${LODEV}p1` and `${LODEV}p2` automatically. A `trap cleanup EXIT` ensures the loop device is always detached, even on error.


`vfat.sh` / `ext4.sh` - mount the partition devices directly instead of computing byte offsets manually.
