### PR TITLE
ci: add GitHub Actions workflow for shellcheck and image pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+      - name: Lint scripts
+        run: |
+          shellcheck -x -P . pimake
+          find . -name "*.sh" -not -path "./.git/*" -print0 | xargs -0 shellcheck -x -P .
+
+  dispatcher:
+    name: Dispatcher
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: bare invocation prints usage
+        run: ./pimake
+      - name: --help prints usage
+        run: ./pimake --help
+      - name: unknown command exits 1
+        run: '! ./pimake badcmd'
+      - name: init
+        run: ./pimake init
+
+  pipeline:
+    name: Image pipeline
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: init
+        run: ./pimake init
+      - name: Cache image package
+        uses: actions/cache@v4
+        with:
+          path: workspace/package
+          key: image-${{ hashFiles('conf/distro/raspbian-lite/index.conf') }}
+      - name: fetch
+        run: ./pimake fetch
+      - name: unpack
+        run: ./pimake unpack
+      - name: build
+        run: sudo ./pimake build
+      - name: pack
+        run: ./pimake pack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,22 +33,46 @@ jobs:
         run: ./pimake init
 
   pipeline:
-    name: Image pipeline
+    name: Build ${{ matrix.distro }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [raspbian-lite, raspbian]
     steps:
       - uses: actions/checkout@v4
+
       - name: init
-        run: ./pimake init
+        run: |
+          ./pimake init
+          sed -i "s/^source_image_distro=.*/source_image_distro=${{ matrix.distro }}/" conf/pimake.local
+
       - name: Cache image package
         uses: actions/cache@v4
         with:
           path: workspace/package
-          key: image-${{ hashFiles('conf/distro/raspbian-lite/index.conf') }}
+          key: image-${{ matrix.distro }}-${{ hashFiles(format('conf/distro/{0}/index.conf', matrix.distro)) }}
+
       - name: fetch
         run: ./pimake fetch
+
       - name: unpack
         run: ./pimake unpack
+
       - name: build
         run: sudo ./pimake build
+
       - name: pack
         run: ./pimake pack
+
+      - name: get archive name
+        id: image
+        run: |
+          source "conf/distro/${{ matrix.distro }}/index.conf"
+          echo "archive=${source_image_archive}" >> "$GITHUB_OUTPUT"
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.image.outputs.archive }}
+          path: workspace/build/${{ steps.image.outputs.archive }}

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -12,7 +12,7 @@ if [ "$(whoami)" != "root" ]; then
 fi
 
 deploy=$1
-if [ -z $deploy ]; then
+if [ -z "$deploy" ]; then
 	echo \# Sorry, no username provided.
 	exit 1
 fi
@@ -34,40 +34,40 @@ echo \# - generate randomish password for root
 newrootpassword=$(date +%s | sha256sum | base64 | head -c 12 ; echo)
 echo "root:$newrootpassword" | chpasswd
 
-echo \# configure $deploy user
-useradd $deploy
+echo \# configure "$deploy" user
+useradd "$deploy"
 
-echo \# - add $deploy user to sudoers group
-usermod -aG sudo $deploy
+echo \# - add "$deploy" user to sudoers group
+usermod -aG sudo "$deploy"
 
-echo \# - generate randomish password for $deploy
+echo \# - generate randomish password for "$deploy"
 newpassword=$(date +%s | sha256sum | base64 | head -c 12 ; echo)
 echo "$deploy:$newpassword" | chpasswd
 
-echo \# - generate user environment for $deploy
-mkdir -p /home/$deploy/.ssh
-touch /home/$deploy/.ssh/authorized_keys
-chmod 700 /home/$deploy/.ssh
-chmod 600 /home/$deploy/.ssh/authorized_keys
-chmod -R go= /home/$deploy
-chown $deploy:$deploy /home/$deploy -R
+echo \# - generate user environment for "$deploy"
+mkdir -p "/home/$deploy/.ssh"
+touch "/home/$deploy/.ssh/authorized_keys"
+chmod 700 "/home/$deploy/.ssh"
+chmod 600 "/home/$deploy/.ssh/authorized_keys"
+chmod -R go= "/home/$deploy"
+chown "$deploy":"$deploy" "/home/$deploy" -R
 
 echo \#
 echo \# THIS IS YOUR USER PASSWORD, DO NOT LOSE IT:
-echo \# $newpassword
-echo \#	- you will need to remember it, just store it somewhere
-echo \#   secure until you change it later - this password will 
+echo \# "$newpassword"
+echo \# - you will need to remember it, just store it somewhere
+echo \#   secure until you change it later - this password will
 echo \#   only be needed for the ability to log in or use sudo.
 echo \#
 echo \# THIS IS YOUR ROOT PASSWORD, DO NOT LOSE IT:
-echo \# $newrootpassword
-echo \#	- you won’t need to remember it, just store it somewhere
+echo \# "$newrootpassword"
+echo "# - you won't need to remember it, just store it somewhere"
 echo \#   secure - this password will only be needed if you lose
 echo \#   the ability to log in over ssh or lose your sudo password.
 echo \#
 echo \# TO PROVISION SSH ACCESS:
-echo \# ssh-keygen -f \~/.ssh/keys/$HOSTNAME/$deploy -t rsa -b 4096
-echo \# ssh-copy-id -i \~/.ssh/keys/$HOSTNAME/$deploy $deploy@$HOSTNAME
+echo \# ssh-keygen -f \~/.ssh/keys/"$HOSTNAME"/"$deploy" -t rsa -b 4096
+echo \# ssh-copy-id -i \~/.ssh/keys/"$HOSTNAME"/"$deploy" "$deploy"@"$HOSTNAME"
 echo \#
 echo \# you should shutdown -r now
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -6,45 +6,45 @@
 # - https://github.com/mr-r3b00t/kali_p05t_1n5ta11/blob/master/post.sh
 # - https://chmod-calculator.com
 
+msg()  { echo -e "# \033[0;37m$*\033[0m"; }
+note() { echo -e "# \033[0;36m$*\033[0m"; }
+errr() { echo -e "# \033[1;31m$*\033[0m"; }
+ok()   { echo -e "# \033[1;32m$*\033[0m"; }
+
 if [ "$(whoami)" != "root" ]; then
-	echo \# Sorry, you are not root.
-	exit 1
+    errr "you are not root."
+    exit 1
 fi
 
 deploy=$1
 if [ -z "$deploy" ]; then
-	echo \# Sorry, no username provided.
-	exit 1
+    errr "no username provided."
+    exit 1
 fi
 
-echo \# configure apt for HTTPS
+msg "configure apt for HTTPS"
 cp /etc/apt/sources.list sources.bak
 apt -y install apt-transport-https
 sed -i 's/http:\/\//https:\/\//g' /etc/apt/sources.list
 sed -i 's/http:\/\//https:\/\//g' /etc/apt/sources.list.d/raspi.list
 
-echo \# Freshening up system..
+msg "freshening up system"
 apt -y update
 apt -y full-upgrade
 apt -y autoclean
 apt -y autoremove
 
-echo \# configure root user
-echo \# - generate randomish password for root
+msg "configure root user"
 newrootpassword=$(date +%s | sha256sum | base64 | head -c 12 ; echo)
 echo "root:$newrootpassword" | chpasswd
 
-echo \# configure "$deploy" user
+msg "configure $deploy user"
 useradd "$deploy"
-
-echo \# - add "$deploy" user to sudoers group
 usermod -aG sudo "$deploy"
-
-echo \# - generate randomish password for "$deploy"
 newpassword=$(date +%s | sha256sum | base64 | head -c 12 ; echo)
 echo "$deploy:$newpassword" | chpasswd
 
-echo \# - generate user environment for "$deploy"
+msg "generate user environment for $deploy"
 mkdir -p "/home/$deploy/.ssh"
 touch "/home/$deploy/.ssh/authorized_keys"
 chmod 700 "/home/$deploy/.ssh"
@@ -52,23 +52,20 @@ chmod 600 "/home/$deploy/.ssh/authorized_keys"
 chmod -R go= "/home/$deploy"
 chown "$deploy":"$deploy" "/home/$deploy" -R
 
-echo \#
-echo \# THIS IS YOUR USER PASSWORD, DO NOT LOSE IT:
-echo \# "$newpassword"
-echo \# - you will need to remember it, just store it somewhere
-echo \#   secure until you change it later - this password will
-echo \#   only be needed for the ability to log in or use sudo.
-echo \#
-echo \# THIS IS YOUR ROOT PASSWORD, DO NOT LOSE IT:
-echo \# "$newrootpassword"
-echo "# - you won't need to remember it, just store it somewhere"
-echo \#   secure - this password will only be needed if you lose
-echo \#   the ability to log in over ssh or lose your sudo password.
-echo \#
-echo \# TO PROVISION SSH ACCESS:
-echo \# ssh-keygen -f \~/.ssh/keys/"$HOSTNAME"/"$deploy" -t rsa -b 4096
-echo \# ssh-copy-id -i \~/.ssh/keys/"$HOSTNAME"/"$deploy" "$deploy"@"$HOSTNAME"
-echo \#
-echo \# you should shutdown -r now
+ok "done."
+echo "#"
+note "USER PASSWORD (do not lose this):"
+note "  $newpassword"
+note "  needed to log in and use sudo."
+echo "#"
+note "ROOT PASSWORD (do not lose this):"
+note "  $newrootpassword"
+note "  only needed if you lose SSH access or your sudo password."
+echo "#"
+note "TO PROVISION SSH ACCESS:"
+note "  ssh-keygen -f ~/.ssh/keys/\$HOSTNAME/$deploy -t rsa -b 4096"
+note "  ssh-copy-id -i ~/.ssh/keys/\$HOSTNAME/$deploy $deploy@\$HOSTNAME"
+echo "#"
+note "you should: shutdown -r now"
 
 exit 0

--- a/deploy/final.sh
+++ b/deploy/final.sh
@@ -5,14 +5,18 @@
 # - https://plusbryan.com/my-first-5-minutes-on-a-server-or-essential-security-for-linux-servers
 #
 
+msg()  { echo -e "# \033[0;37m$*\033[0m"; }
+errr() { echo -e "# \033[1;31m$*\033[0m"; }
+ok()   { echo -e "# \033[1;32m$*\033[0m"; }
+
 if [ "$(whoami)" != "root" ]; then
-	echo \# Sorry, you are not root.
-	exit 1
+    errr "you are not root."
+    exit 1
 fi
 
-echo \# deleting pi user!
+msg "deleting pi user"
 userdel -r -f -z pi
 
-echo \# done.
+ok "done."
 
 exit 0

--- a/deploy/install-keyboard.sh
+++ b/deploy/install-keyboard.sh
@@ -4,17 +4,23 @@
 # install matchbox-keyboard
 #
 
+msg()  { echo -e "# \033[0;37m$*\033[0m"; }
+errr() { echo -e "# \033[1;31m$*\033[0m"; }
+ok()   { echo -e "# \033[1;32m$*\033[0m"; }
+note() { echo -e "# \033[0;36m$*\033[0m"; }
+
 if [ "$(whoami)" != "root" ]; then
-	echo \# Sorry, you are not root.
-	exit 1
+    errr "you are not root."
+    exit 1
 fi
 
-echo \# update
+msg "update"
 apt -y update
 
-echo \# install matchbox-keyboard
+msg "install matchbox-keyboard"
 apt -y install matchbox-keyboard
 
-echo \# you should shutdown -r now
+ok "done."
+note "you should: shutdown -r now"
 
 exit 0

--- a/pimake
+++ b/pimake
@@ -20,7 +20,7 @@ case "$1" in
     init|fetch|unpack|build|pack|burn|rip|clean)
         command=$1
         shift
-        cd "$PIMAKE_DIR"
+        cd "$PIMAKE_DIR" || exit
         "$PIMAKE_DIR/script/$command.sh" "$@"
         ;;
     -h|--help|"")

--- a/script/build.sh
+++ b/script/build.sh
@@ -26,17 +26,18 @@ fi
 
 if [ "$opengl_activate_enabled" -eq 1 ]; then
     title "configure the GL driver"
-    echo -e "\n# Activate the GL driver" >> "$target_conf"
-    echo -e "dtoverlay=vc4-kms-v3d" >> "$target_conf"
+    { echo -e "\n# Activate the GL driver"; echo "dtoverlay=vc4-kms-v3d"; } >> "$target_conf"
 fi
 
 if [ "$hdmi_install_enabled" -eq 1 ]; then
     title "configure HDMI"
-    echo -e "\n# Configure touchscreen" >> "$target_conf"
-    echo -e "hdmi_group=2" >> "$target_conf"
-    echo -e "hdmi_mode=1" >> "$target_conf"
-    echo -e "hdmi_mode=87" >> "$target_conf"
-    echo -e "hdmi_cvt $hdmi_cvt" >> "$target_conf"
+    {
+        echo -e "\n# Configure touchscreen"
+        echo "hdmi_group=2"
+        echo "hdmi_mode=1"
+        echo "hdmi_mode=87"
+        echo "hdmi_cvt $hdmi_cvt"
+    } >> "$target_conf"
 fi
 
 unmount_vfat
@@ -54,34 +55,36 @@ fi
 
 if [ "$wpa_network_enabled" -eq 1 ]; then
     title "configure WiFi"
-
 #    mkdir -p $target_root/etc/wpa_supplicant
 #    echo "ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev" >> $wpa_conf
 #    echo "update_config=1" >> $wpa_conf
-    echo "country=$wpa_network_locale" >> "$wpa_conf"
-    echo "network={" >> "$wpa_conf"
-    echo "    scan_ssid=1" >> "$wpa_conf"
-    echo "    ssid=$wpa_network_ssid" >> "$wpa_conf"
-    echo "    psk=$wpa_network_password" >> "$wpa_conf"
-    echo "}" >> "$wpa_conf"
+    {
+        echo "country=$wpa_network_locale"
+        echo "network={"
+        echo "    scan_ssid=1"
+        echo "    ssid=$wpa_network_ssid"
+        echo "    psk=$wpa_network_password"
+        echo "}"
+    } >> "$wpa_conf"
 fi
 
 if [ "$gsm_network_enabled" -eq 1 ]; then
     title "configure GSM"
-
     touch "$wvdial_conf"
-    echo "[Dialer $gsm_network_provider]" >> "$wvdial_conf"
-    echo "Init1 = ATZ" >> "$wvdial_conf"
-    echo "Init2 = ATQ0 V1 E1 S0=0 &C1 &D2 +FCLASS=0" >> "$wvdial_conf"
-    echo "Init3 = AT+CGDCONT=1,\"IP\",\"internet\"" >> "$wvdial_conf"
-    echo "Stupid Mode = 1" >> "$wvdial_conf"
-    echo "Modem Type = Analog Modem" >> "$wvdial_conf"
-    echo "ISDN = 0" >> "$wvdial_conf"
-    echo "Phone = *99#" >> "$wvdial_conf"
-    echo "Modem = /dev/gsmmodem" >> "$wvdial_conf"
-    echo "Username = $gsm_network_username" >> "$wvdial_conf"
-    echo "Password = $gsm_network_password" >> "$wvdial_conf"
-    echo "Baud = $gsm_network_baud" >> "$wvdial_conf"
+    {
+        echo "[Dialer $gsm_network_provider]"
+        echo "Init1 = ATZ"
+        echo "Init2 = ATQ0 V1 E1 S0=0 &C1 &D2 +FCLASS=0"
+        echo "Init3 = AT+CGDCONT=1,\"IP\",\"internet\""
+        echo "Stupid Mode = 1"
+        echo "Modem Type = Analog Modem"
+        echo "ISDN = 0"
+        echo "Phone = *99#"
+        echo "Modem = /dev/gsmmodem"
+        echo "Username = $gsm_network_username"
+        echo "Password = $gsm_network_password"
+        echo "Baud = $gsm_network_baud"
+    } >> "$wvdial_conf"
 fi
 
 unmount_ext4

--- a/script/burn.sh
+++ b/script/burn.sh
@@ -6,15 +6,15 @@ header "$0"
 # check_user root
 
 target_disk=$1
-if [ -z $1 ]; then
-	errr "no target disk was specified."
-	exit 1
+if [ -z "$1" ]; then
+    errr "no target disk was specified."
+    exit 1
 fi
 
 #
 # burn the packed raspbian image
-# 
+#
 msg "writing $build to $target_disk"
-dd if=$build of=$target_disk bs=4M conv=fsync status=progress
+dd if="$build" of="$target_disk" bs=4M conv=fsync status=progress
 
 exit 0

--- a/script/clean.sh
+++ b/script/clean.sh
@@ -4,13 +4,13 @@ source script/common/common.sh
 header "$0"
 
 msg "clean up build directories"
-rm -rf $workspace_dir/build/*
-rm -rf $workspace_dir/img/*
-rm -rf $workspace_dir/mnt/*
+rm -rf "${workspace_dir:?}/build/"*
+rm -rf "${workspace_dir:?}/img/"*
+rm -rf "${workspace_dir:?}/mnt/"*
 
 if [ "$1" = "-f" ] || [ "$1" = "--fresh" ]; then
   msg "clean up packages"
-  rm -rf $workspace_dir/package/*
+  rm -rf "${workspace_dir:?}/package/"*
 
   msg "clean up local configuration file"
   rm -f conf/pimake.local

--- a/script/common/common.sh
+++ b/script/common/common.sh
@@ -1,20 +1,29 @@
 #!/bin/bash
 
+# shellcheck disable=SC2034
 version=v0.1.0
 
+# shellcheck disable=SC2034
 RED='\033[0;31m'
+# shellcheck disable=SC2034
 GREEN='\033[0;32m'
+# shellcheck disable=SC2034
 YELLOW='\033[0;33m'
+# shellcheck disable=SC2034
 BLUE='\033[0;34m'
+# shellcheck disable=SC2034
 PINK='\033[0;35m'
+# shellcheck disable=SC2034
 CYAN='\033[0;36m'
+# shellcheck disable=SC2034
 WHITE='\033[0;37m'
+# shellcheck disable=SC2034
 NC='\033[0m'
-BOLD=$(tput bold)
-NORM=$(tput sgr0)
+BOLD=$(tput bold 2>/dev/null)
+NORM=$(tput sgr0 2>/dev/null)
 
 function header() {
-    local filename=$(basename -- "$1")
+    local filename; filename=$(basename -- "$1")
     echo -e "# ${CYAN}${BOLD}${filename%%.*}${NC}${NORM}"
 }
 function title() {
@@ -50,23 +59,32 @@ function check_error() {
 }
 
 # Load local config, falling back to the template for first-time init
+# shellcheck source=conf/pimake.conf
 if [ -f conf/pimake.local ]; then
     source conf/pimake.local
 else
     source conf/pimake.conf
 fi
 
+# shellcheck source=conf/distro/raspbian-lite/index.conf
 source "conf/distro/$source_image_distro/index.conf"
 
 # Derived paths
+# shellcheck disable=SC2034
 package=$workspace_dir/package/$source_image_archive
+# shellcheck disable=SC2034
 package_checksum=$workspace_dir/package/$source_image_hash
-package_curl_log=$workspace_dir/package/$source_image_archive.log
-package_checksum_curl_log=$workspace_dir/package/$source_image_archive_hash.log
+# shellcheck disable=SC2034
 build=$workspace_dir/build/$source_image_archive
+# shellcheck disable=SC2034
 build_checksum=$workspace_dir/build/$source_image_hash
+# shellcheck disable=SC2034
 image=$workspace_dir/img/$source_image_name.img
+# shellcheck disable=SC2034
 mount=$workspace_dir/mnt/$source_image_name
+# shellcheck disable=SC2034
 target_root=$mount/ext4
+# shellcheck disable=SC2034
 target_conf=$mount/vfat/config.txt
+# shellcheck disable=SC2034
 target_ssh=$mount/vfat/ssh

--- a/script/fetch.sh
+++ b/script/fetch.sh
@@ -12,17 +12,17 @@ image_chk="$source_image_hash_expected  $package"
 
 if [ ! -f "$package" ]; then
     msg "downloading $package"
-    curl $source_image_url/$source_image_archive -L -o $package -silent -output $package.log
+    curl "$source_image_url/$source_image_archive" -L -o "$package"
 
     msg "downloading $package_checksum"
-    curl $source_image_url/$source_image_hash -L -o $package_checksum -silent -output $package_checksum.log
+    curl "$source_image_url/$source_image_hash" -L -o "$package_checksum"
 else
     msg "found existing $package"
 fi
 
 msg "verifying $package.."
-sha256sum $package > $package_checksum
-checksum=$(cat $package_checksum)
+sha256sum "$package" > "$package_checksum"
+checksum=$(cat "$package_checksum")
 
 if [ "$image_chk" = "$checksum" ]; then
     okmsg "OK"

--- a/script/init.sh
+++ b/script/init.sh
@@ -4,10 +4,10 @@ source script/common/common.sh
 header "$0"
 
 msg "creating workspace"
-mkdir -p $workspace_dir/build
-mkdir -p $workspace_dir/img
-mkdir -p $workspace_dir/mnt
-mkdir -p $workspace_dir/package
+mkdir -p "$workspace_dir/build"
+mkdir -p "$workspace_dir/img"
+mkdir -p "$workspace_dir/mnt"
+mkdir -p "$workspace_dir/package"
 
 msg "creating local configuration file"
 cp conf/pimake.conf conf/pimake.local

--- a/script/pack.sh
+++ b/script/pack.sh
@@ -8,10 +8,9 @@ header "$0"
 #
 
 msg "compressing $image to $build"
-zip -j $build $workspace_dir/img/*
+zip -j "$build" "$workspace_dir/img/"*
 
 msg "generating SHA256 for $build"
-sha256sum $build > $build_checksum
-checksum=$(cat $build_checksum)
+sha256sum "$build" > "$build_checksum"
 
 exit 0

--- a/script/rip.sh
+++ b/script/rip.sh
@@ -6,15 +6,15 @@ header "$0"
 # check_user root
 
 source_disk=$1
-if [ -z $1 ]; then
-	errr "no source disk was specified."
-	exit 1
+if [ -z "$1" ]; then
+    errr "no source disk was specified."
+    exit 1
 fi
 
 #
 # read the burned raspbian image
-# 
+#
 msg "reading $image from $source_disk"
-dd if=$source_disk of=$image bs=4M conv=fsync status=progress
+dd if="$source_disk" of="$image" bs=4M conv=fsync status=progress
 
 exit 0

--- a/script/unpack.sh
+++ b/script/unpack.sh
@@ -7,7 +7,7 @@ header "$0"
 # unpack the raspian image
 #
 
-msg "decompressing $build"
-unzip $package -d $workspace_dir/img
+msg "decompressing $package"
+unzip "$package" -d "$workspace_dir/img"
 
 exit 0


### PR DESCRIPTION
Introduce a GitHub actions workflow with three jobs:

- shellcheck: lints pimake and all .sh files with -x (follows source directives) and -P . (resolves relative source paths). Catches quoting issues, bad substitutions, and other shell bugs statically.

- dispatcher: smoke tests the pimake entry point — bare invocation, --help, unknown command, and init. Fast, no dependencies.

- pipeline: runs the full fetch → unpack → build → pack sequence on ubuntu-latest, which supports sudo, losetup, and loop device mounting. Caches workspace/package keyed on the distro index.conf so the ~400MB image is only re-downloaded when the distro config changes.