### PR TITLE
ux: burn/rip autodetect removable devices and require confirmation

### DIFF
--- a/pimake
+++ b/pimake
@@ -11,8 +11,8 @@ usage() {
     echo "  unpack   Extract image archive"
     echo "  build    Mount and configure image (requires sudo)"
     echo "  pack     Recompress image"
-    echo "  burn     Flash image to disk"
-    echo "  rip      Extract image from existing disk"
+    echo "  burn     Flash image to disk (prompts for device; use --device /dev/sdX to skip)"
+    echo "  rip      Extract image from existing disk (prompts for device; use --device /dev/sdX to skip)"
     echo "  clean    Remove build artifacts (--fresh to reset all)"
 }
 

--- a/script/burn.sh
+++ b/script/burn.sh
@@ -5,10 +5,53 @@ header "$0"
 
 # check_user root
 
-target_disk=$1
-if [ -z "$1" ]; then
-    errr "no target disk was specified."
+# Resolve target device: --device flag, positional arg, or interactive picker
+target_disk=""
+if [ "$1" = "--device" ] && [ -n "$2" ]; then
+    target_disk=$2
+elif [ -n "$1" ] && [ "$1" != "--device" ]; then
+    target_disk=$1
+fi
+
+if [ -z "$target_disk" ]; then
+    mapfile -t _devs < <(lsblk -d -o NAME,RM --noheadings 2>/dev/null | awk '$2 == 1 {print $1}')
+    if [ ${#_devs[@]} -eq 0 ]; then
+        errr "No removable block devices found. Insert your SD card or use --device /dev/sdX."
+        exit 1
+    fi
+    title "Available removable devices:"
+    for i in "${!_devs[@]}"; do
+        _info=$(lsblk -d -o SIZE,MODEL --noheadings "/dev/${_devs[$i]}" 2>/dev/null | xargs)
+        msg "  $((i+1)))  /dev/${_devs[$i]}  $_info"
+    done
+    echo ""
+    echo -en "# Enter number [1-${#_devs[@]}] or device path: "
+    read -r _pick
+    if [[ "$_pick" =~ ^[0-9]+$ ]] && [ "$_pick" -ge 1 ] && [ "$_pick" -le "${#_devs[@]}" ]; then
+        target_disk="/dev/${_devs[$((_pick - 1))]}"
+    else
+        target_disk="$_pick"
+    fi
+fi
+
+if [ ! -b "$target_disk" ]; then
+    errr "$target_disk is not a block device."
     exit 1
+fi
+
+# Confirm before writing
+_info=$(lsblk -d -o SIZE,MODEL --noheadings "$target_disk" 2>/dev/null | xargs)
+echo ""
+title "Confirm write"
+msg "  image:   $build"
+msg "  device:  $target_disk  $_info"
+echo ""
+warn "All data on $target_disk will be permanently erased."
+echo -en "# Type 'yes' to continue: "
+read -r _confirm
+if [ "$_confirm" != "yes" ]; then
+    msg "Aborted."
+    exit 0
 fi
 
 #

--- a/script/burn.sh
+++ b/script/burn.sh
@@ -14,24 +14,8 @@ elif [ -n "$1" ] && [ "$1" != "--device" ]; then
 fi
 
 if [ -z "$target_disk" ]; then
-    mapfile -t _devs < <(lsblk -d -o NAME,RM --noheadings 2>/dev/null | awk '$2 == 1 {print $1}')
-    if [ ${#_devs[@]} -eq 0 ]; then
-        errr "No removable block devices found. Insert your SD card or use --device /dev/sdX."
-        exit 1
-    fi
-    title "Available removable devices:"
-    for i in "${!_devs[@]}"; do
-        _info=$(lsblk -d -o SIZE,MODEL --noheadings "/dev/${_devs[$i]}" 2>/dev/null | xargs)
-        msg "  $((i+1)))  /dev/${_devs[$i]}  $_info"
-    done
-    echo ""
-    echo -en "# Enter number [1-${#_devs[@]}] or device path: "
-    read -r _pick
-    if [[ "$_pick" =~ ^[0-9]+$ ]] && [ "$_pick" -ge 1 ] && [ "$_pick" -le "${#_devs[@]}" ]; then
-        target_disk="/dev/${_devs[$((_pick - 1))]}"
-    else
-        target_disk="$_pick"
-    fi
+    pick_removable_device || exit 1
+    target_disk=$selected_device
 fi
 
 if [ ! -b "$target_disk" ]; then
@@ -40,11 +24,10 @@ if [ ! -b "$target_disk" ]; then
 fi
 
 # Confirm before writing
-_info=$(lsblk -d -o SIZE,MODEL --noheadings "$target_disk" 2>/dev/null | xargs)
 echo ""
 title "Confirm write"
 msg "  image:   $build"
-msg "  device:  $target_disk  $_info"
+msg "  device:  $target_disk  $(device_info "$target_disk")"
 echo ""
 warn "All data on $target_disk will be permanently erased."
 echo -en "# Type 'yes' to continue: "

--- a/script/common/common.sh
+++ b/script/common/common.sh
@@ -42,6 +42,34 @@ function okmsg() {
     echo -e "# ${GREEN}${BOLD}$1${NC}${NORM}"
 }
 
+# Returns SIZE and MODEL for a block device, space-separated.
+function device_info() {
+    lsblk -d -o SIZE,MODEL --noheadings "$1" 2>/dev/null | xargs
+}
+
+# Lists removable block devices and prompts the user to choose one.
+# Sets the global variable $selected_device on success; returns 1 if none found.
+function pick_removable_device() {
+    local -a _devs
+    mapfile -t _devs < <(lsblk -d -o NAME,RM --noheadings 2>/dev/null | awk '$2 == 1 {print $1}')
+    if [ ${#_devs[@]} -eq 0 ]; then
+        errr "No removable block devices found. Insert your SD card or use --device /dev/sdX."
+        return 1
+    fi
+    title "Available removable devices:"
+    for i in "${!_devs[@]}"; do
+        msg "  $((i+1)))  /dev/${_devs[$i]}  $(device_info "/dev/${_devs[$i]}")"
+    done
+    echo ""
+    echo -en "# Enter number [1-${#_devs[@]}] or device path: "
+    read -r _pick
+    if [[ "$_pick" =~ ^[0-9]+$ ]] && [ "$_pick" -ge 1 ] && [ "$_pick" -le "${#_devs[@]}" ]; then
+        selected_device="/dev/${_devs[$((_pick - 1))]}"
+    else
+        selected_device="$_pick"
+    fi
+}
+
 function check_user() {
     if [ "$(whoami)" = "$1" ]; then
         return 1

--- a/script/rip.sh
+++ b/script/rip.sh
@@ -5,10 +5,52 @@ header "$0"
 
 # check_user root
 
-source_disk=$1
-if [ -z "$1" ]; then
-    errr "no source disk was specified."
+# Resolve source device: --device flag, positional arg, or interactive picker
+source_disk=""
+if [ "$1" = "--device" ] && [ -n "$2" ]; then
+    source_disk=$2
+elif [ -n "$1" ] && [ "$1" != "--device" ]; then
+    source_disk=$1
+fi
+
+if [ -z "$source_disk" ]; then
+    mapfile -t _devs < <(lsblk -d -o NAME,RM --noheadings 2>/dev/null | awk '$2 == 1 {print $1}')
+    if [ ${#_devs[@]} -eq 0 ]; then
+        errr "No removable block devices found. Insert your SD card or use --device /dev/sdX."
+        exit 1
+    fi
+    title "Available removable devices:"
+    for i in "${!_devs[@]}"; do
+        _info=$(lsblk -d -o SIZE,MODEL --noheadings "/dev/${_devs[$i]}" 2>/dev/null | xargs)
+        msg "  $((i+1)))  /dev/${_devs[$i]}  $_info"
+    done
+    echo ""
+    echo -en "# Enter number [1-${#_devs[@]}] or device path: "
+    read -r _pick
+    if [[ "$_pick" =~ ^[0-9]+$ ]] && [ "$_pick" -ge 1 ] && [ "$_pick" -le "${#_devs[@]}" ]; then
+        source_disk="/dev/${_devs[$((_pick - 1))]}"
+    else
+        source_disk="$_pick"
+    fi
+fi
+
+if [ ! -b "$source_disk" ]; then
+    errr "$source_disk is not a block device."
     exit 1
+fi
+
+# Confirm before reading
+_info=$(lsblk -d -o SIZE,MODEL --noheadings "$source_disk" 2>/dev/null | xargs)
+echo ""
+title "Confirm read"
+msg "  source:  $source_disk  $_info"
+msg "  image:   $image"
+echo ""
+echo -en "# Type 'yes' to continue: "
+read -r _confirm
+if [ "$_confirm" != "yes" ]; then
+    msg "Aborted."
+    exit 0
 fi
 
 #

--- a/script/rip.sh
+++ b/script/rip.sh
@@ -14,24 +14,8 @@ elif [ -n "$1" ] && [ "$1" != "--device" ]; then
 fi
 
 if [ -z "$source_disk" ]; then
-    mapfile -t _devs < <(lsblk -d -o NAME,RM --noheadings 2>/dev/null | awk '$2 == 1 {print $1}')
-    if [ ${#_devs[@]} -eq 0 ]; then
-        errr "No removable block devices found. Insert your SD card or use --device /dev/sdX."
-        exit 1
-    fi
-    title "Available removable devices:"
-    for i in "${!_devs[@]}"; do
-        _info=$(lsblk -d -o SIZE,MODEL --noheadings "/dev/${_devs[$i]}" 2>/dev/null | xargs)
-        msg "  $((i+1)))  /dev/${_devs[$i]}  $_info"
-    done
-    echo ""
-    echo -en "# Enter number [1-${#_devs[@]}] or device path: "
-    read -r _pick
-    if [[ "$_pick" =~ ^[0-9]+$ ]] && [ "$_pick" -ge 1 ] && [ "$_pick" -le "${#_devs[@]}" ]; then
-        source_disk="/dev/${_devs[$((_pick - 1))]}"
-    else
-        source_disk="$_pick"
-    fi
+    pick_removable_device || exit 1
+    source_disk=$selected_device
 fi
 
 if [ ! -b "$source_disk" ]; then
@@ -40,10 +24,9 @@ if [ ! -b "$source_disk" ]; then
 fi
 
 # Confirm before reading
-_info=$(lsblk -d -o SIZE,MODEL --noheadings "$source_disk" 2>/dev/null | xargs)
 echo ""
 title "Confirm read"
-msg "  source:  $source_disk  $_info"
+msg "  source:  $source_disk  $(device_info "$source_disk")"
 msg "  image:   $image"
 echo ""
 echo -en "# Type 'yes' to continue: "


### PR DESCRIPTION
Closes #7. Both commands now use lsblk to list removable block devices
and present a numbered picker when no device is specified. A --device
flag skips the picker for scripted use. Either way, the target device
details are shown and an explicit 'yes' prompt gates the dd call.