### PR TITLE
feat: add pimake vm — QEMU emulation lifecycle commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,6 @@ jobs:
       - name: Install QEMU and mtools
         run: sudo apt-get install -y qemu-system-arm qemu-system-aarch64 mtools
 
-      - name: generate SSH key
-        run: ssh-keygen -t ed25519 -N "" -f ci_key
-
       - name: init workspace
         run: |
           ./pimake init
@@ -111,7 +108,6 @@ jobs:
           sed -i 's/^user_configure_enabled=.*/user_configure_enabled=1/' conf/pimake.local
           sed -i 's/^user_name=.*/user_name=pimake/' conf/pimake.local
           sed -i 's/^user_password=.*/user_password=testpassword/' conf/pimake.local
-          echo "user_ssh_public_key=\"$(cat ci_key.pub)\"" >> conf/pimake.local
 
       - name: Cache image package
         uses: actions/cache@v4
@@ -143,7 +139,7 @@ jobs:
       - name: show VM
         run: ./pimake vm show --pid "$VM_PID"
 
-      - name: wait for SSH and smoke test
+      - name: wait for boot
         timeout-minutes: 25
         run: |
           log="workspace/qemu/qemu-${VM_SSH_PORT}.log"
@@ -157,7 +153,9 @@ jobs:
             if grep -q 'login:' "$log" 2>/dev/null; then
               echo ""
               echo "login prompt detected after $(( now - (deadline - 1200) ))s"
-              break
+              echo "--- boot log tail ---"
+              tail -20 "$log"
+              exit 0
             fi
             if [ "$now" -ge "$deadline" ]; then
               echo ""
@@ -168,33 +166,13 @@ jobs:
             fi
             if [ $(( now - last_report )) -ge 120 ]; then
               echo ""
-              echo "--- still booting ($(( now - (deadline - 1200) ))s elapsed), last log line: ---"
-              tail -1 "$log" 2>/dev/null || true
+              echo "--- still booting ($(( now - (deadline - 1200) ))s elapsed) ---"
+              tail -30 "$log" 2>/dev/null || echo "(log empty — possible console mismatch)"
               last_report=$now
             fi
             printf '.'
             sleep 1
           done
-          echo "connecting via SSH..."
-          for i in 1 2 3 4 5; do
-            if out=$(ssh -i ci_key \
-                         -o StrictHostKeyChecking=no \
-                         -o BatchMode=yes \
-                         -o ConnectTimeout=10 \
-                         -p "$VM_SSH_PORT" \
-                         pimake@localhost 'uname -a && cat /etc/os-release' 2>&1); then
-              echo "--- smoke test output ---"
-              echo "$out"
-              echo "-------------------------"
-              echo "SSH smoke test passed"
-              exit 0
-            fi
-            sleep 3
-          done
-          echo "SSH failed after login prompt appeared" >&2
-          echo "--- QEMU log (last 60 lines) ---" >&2
-          tail -60 "$log" >&2
-          exit 1
 
       - name: stop VM
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
       - name: Install QEMU and mtools
         run: sudo apt-get install -y qemu-system-arm qemu-system-aarch64 mtools
 
+      - name: generate SSH key
+        run: ssh-keygen -t ed25519 -N "" -f ci_key
+
       - name: init workspace
         run: |
           ./pimake init
@@ -108,6 +111,7 @@ jobs:
           sed -i 's/^user_configure_enabled=.*/user_configure_enabled=1/' conf/pimake.local
           sed -i 's/^user_name=.*/user_name=pimake/' conf/pimake.local
           sed -i 's/^user_password=.*/user_password=testpassword/' conf/pimake.local
+          echo "user_ssh_public_key=\"$(cat ci_key.pub)\"" >> conf/pimake.local
 
       - name: Cache image package
         uses: actions/cache@v4
@@ -155,7 +159,24 @@ jobs:
               echo "login prompt detected after $(( now - (deadline - 1200) ))s"
               echo "--- boot log tail ---"
               tail -20 "$log"
-              exit 0
+              echo "--- connecting via SSH ---"
+              for i in 1 2 3 4 5; do
+                if out=$(ssh -i ci_key \
+                             -o StrictHostKeyChecking=no \
+                             -o BatchMode=yes \
+                             -o ConnectTimeout=10 \
+                             -p "$VM_SSH_PORT" \
+                             pimake@localhost 'uname -a && cat /etc/os-release' 2>&1); then
+                  echo "$out"
+                  echo "SSH smoke test passed"
+                  exit 0
+                fi
+                sleep 5
+              done
+              echo "SSH failed after login prompt appeared" >&2
+              echo "--- QEMU log (last 30 lines) ---" >&2
+              tail -30 "$log" >&2
+              exit 1
             fi
             if [ "$now" -ge "$deadline" ]; then
               echo ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,15 +86,19 @@ jobs:
           path: workspace/build/${{ steps.image.outputs.archive }}
 
   emulate:
-    name: Emulate raspbian-lite
+    name: Emulate ${{ matrix.distro }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [raspbian-lite, ubuntu]
     env:
-      DISTRO: raspbian-lite
+      DISTRO: ${{ matrix.distro }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Install QEMU and mtools
-        run: sudo apt-get install -y qemu-system-arm mtools
+        run: sudo apt-get install -y qemu-system-arm qemu-system-aarch64 mtools
 
       - name: generate SSH key
         run: ssh-keygen -t ed25519 -N "" -f ci_key
@@ -141,20 +145,29 @@ jobs:
 
       - name: wait for SSH and smoke test
         run: |
-          echo "waiting for SSH on port $VM_SSH_PORT..."
-          for i in $(seq 1 60); do
-            if ssh -i ci_key \
-                   -o StrictHostKeyChecking=no \
-                   -o BatchMode=yes \
-                   -o ConnectTimeout=5 \
-                   -p "$VM_SSH_PORT" \
-                   pimake@localhost 'uname -a && cat /etc/os-release' 2>/dev/null; then
+          echo "waiting for SSH on port $VM_SSH_PORT (up to 10 min)..."
+          for i in $(seq 1 120); do
+            printf "[%3ds] trying SSH... " "$((i * 5))"
+            out=$(ssh -i ci_key \
+                      -o StrictHostKeyChecking=no \
+                      -o BatchMode=yes \
+                      -o ConnectTimeout=5 \
+                      -p "$VM_SSH_PORT" \
+                      pimake@localhost 'uname -a && cat /etc/os-release' 2>&1)
+            rc=$?
+            if [ "$rc" -eq 0 ]; then
+              echo "connected!"
+              echo "--- smoke test output ---"
+              echo "$out"
+              echo "-------------------------"
               echo "SSH smoke test passed after $((i * 5))s"
               exit 0
             fi
+            echo "not yet (rc=$rc)"
             sleep 5
           done
-          echo "Timeout: SSH not available after 5 minutes" >&2
+          echo "Timeout: SSH not available after 10 minutes" >&2
+          echo "--- QEMU log ---" >&2
           cat workspace/qemu/qemu-"${VM_SSH_PORT}".log >&2
           exit 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,57 @@ jobs:
         with:
           name: ${{ steps.image.outputs.archive }}
           path: workspace/build/${{ steps.image.outputs.archive }}
+
+  emulate:
+    name: Emulate raspbian-lite
+    runs-on: ubuntu-latest
+    env:
+      DISTRO: raspbian-lite
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install QEMU and mtools
+        run: sudo apt-get install -y qemu-system-arm mtools
+
+      - name: init workspace
+        run: |
+          ./pimake init
+          sed -i "s/^source_image_distro=.*/source_image_distro=${{ env.DISTRO }}/" conf/pimake.local
+          sed -i 's/^ssh_configure_enabled=.*/ssh_configure_enabled=1/' conf/pimake.local
+          sed -i 's/^user_configure_enabled=.*/user_configure_enabled=1/' conf/pimake.local
+          sed -i 's/^user_name=.*/user_name=pimake/' conf/pimake.local
+          sed -i 's/^user_password=.*/user_password=testpassword/' conf/pimake.local
+
+      - name: Cache image package
+        uses: actions/cache@v4
+        with:
+          path: workspace/package
+          key: image-${{ env.DISTRO }}-${{ hashFiles(format('conf/distro/{0}/index.conf', env.DISTRO)) }}
+
+      - name: fetch
+        run: ./pimake fetch
+
+      - name: unpack
+        run: ./pimake unpack
+
+      - name: build
+        run: sudo ./pimake build
+
+      - name: start VM
+        run: ./pimake vm start
+
+      - name: list VMs
+        run: ./pimake vm list
+
+      - name: show VM
+        run: ./pimake vm show
+
+      - name: verify still running after 10s
+        run: |
+          sleep 10
+          ./pimake vm list
+          ./pimake vm show
+
+      - name: stop VM
+        if: always()
+        run: ./pimake vm stop || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,14 +148,12 @@ jobs:
           echo "waiting for SSH on port $VM_SSH_PORT (up to 10 min)..."
           for i in $(seq 1 120); do
             printf "[%3ds] trying SSH... " "$((i * 5))"
-            out=$(ssh -i ci_key \
-                      -o StrictHostKeyChecking=no \
-                      -o BatchMode=yes \
-                      -o ConnectTimeout=5 \
-                      -p "$VM_SSH_PORT" \
-                      pimake@localhost 'uname -a && cat /etc/os-release' 2>&1)
-            rc=$?
-            if [ "$rc" -eq 0 ]; then
+            if out=$(ssh -i ci_key \
+                         -o StrictHostKeyChecking=no \
+                         -o BatchMode=yes \
+                         -o ConnectTimeout=5 \
+                         -p "$VM_SSH_PORT" \
+                         pimake@localhost 'uname -a && cat /etc/os-release' 2>&1); then
               echo "connected!"
               echo "--- smoke test output ---"
               echo "$out"
@@ -163,7 +161,7 @@ jobs:
               echo "SSH smoke test passed after $((i * 5))s"
               exit 0
             fi
-            echo "not yet (rc=$rc)"
+            echo "not yet"
             sleep 5
           done
           echo "Timeout: SSH not available after 10 minutes" >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
       - name: Install QEMU and mtools
         run: sudo apt-get install -y qemu-system-arm mtools
 
+      - name: generate SSH key
+        run: ssh-keygen -t ed25519 -N "" -f ci_key
+
       - name: init workspace
         run: |
           ./pimake init
@@ -104,6 +107,7 @@ jobs:
           sed -i 's/^user_configure_enabled=.*/user_configure_enabled=1/' conf/pimake.local
           sed -i 's/^user_name=.*/user_name=pimake/' conf/pimake.local
           sed -i 's/^user_password=.*/user_password=testpassword/' conf/pimake.local
+          echo "user_ssh_public_key=\"$(cat ci_key.pub)\"" >> conf/pimake.local
 
       - name: Cache image package
         uses: actions/cache@v4
@@ -121,11 +125,13 @@ jobs:
         run: sudo ./pimake build
 
       - name: start VM
+        run: ./pimake vm start
+
+      - name: capture VM info
         run: |
-          output=$(./pimake vm start)
-          echo "$output"
-          pid=$(echo "$output" | grep -o 'pid [0-9]*' | grep -o '[0-9]*')
-          echo "VM_PID=$pid" >> "$GITHUB_ENV"
+          state=$(ls -t workspace/qemu/*.state | head -1)
+          echo "VM_PID=$(grep '^qemu_pid=' "$state" | cut -d= -f2)" >> "$GITHUB_ENV"
+          echo "VM_SSH_PORT=$(grep '^qemu_ssh_port=' "$state" | cut -d= -f2)" >> "$GITHUB_ENV"
 
       - name: list VMs
         run: ./pimake vm list
@@ -133,11 +139,24 @@ jobs:
       - name: show VM
         run: ./pimake vm show --pid "$VM_PID"
 
-      - name: verify still running after 10s
+      - name: wait for SSH and smoke test
         run: |
-          sleep 10
-          ./pimake vm list
-          ./pimake vm show --pid "$VM_PID"
+          echo "waiting for SSH on port $VM_SSH_PORT..."
+          for i in $(seq 1 60); do
+            if ssh -i ci_key \
+                   -o StrictHostKeyChecking=no \
+                   -o BatchMode=yes \
+                   -o ConnectTimeout=5 \
+                   -p "$VM_SSH_PORT" \
+                   pimake@localhost 'uname -a && cat /etc/os-release' 2>/dev/null; then
+              echo "SSH smoke test passed after $((i * 5))s"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Timeout: SSH not available after 5 minutes" >&2
+          cat workspace/qemu/qemu-"${VM_SSH_PORT}".log >&2
+          exit 1
 
       - name: stop VM
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,28 +145,33 @@ jobs:
 
       - name: wait for SSH and smoke test
         run: |
-          echo "waiting for SSH on port $VM_SSH_PORT (up to 10 min)..."
-          for i in $(seq 1 120); do
-            printf "[%3ds] trying SSH... " "$((i * 5))"
+          log="workspace/qemu/qemu-${VM_SSH_PORT}.log"
+          echo "waiting for guest login prompt in serial log (up to 10 min)..."
+          if ! timeout 600 grep -qm1 'login:' <(tail -f "$log" 2>/dev/null); then
+            echo "Timeout: guest never reached login prompt" >&2
+            echo "--- QEMU log ---" >&2
+            cat "$log" >&2
+            exit 1
+          fi
+          echo "login prompt detected — connecting via SSH..."
+          for i in 1 2 3 4 5; do
             if out=$(ssh -i ci_key \
                          -o StrictHostKeyChecking=no \
                          -o BatchMode=yes \
-                         -o ConnectTimeout=5 \
+                         -o ConnectTimeout=10 \
                          -p "$VM_SSH_PORT" \
                          pimake@localhost 'uname -a && cat /etc/os-release' 2>&1); then
-              echo "connected!"
               echo "--- smoke test output ---"
               echo "$out"
               echo "-------------------------"
-              echo "SSH smoke test passed after $((i * 5))s"
+              echo "SSH smoke test passed"
               exit 0
             fi
-            echo "not yet"
-            sleep 5
+            sleep 3
           done
-          echo "Timeout: SSH not available after 10 minutes" >&2
+          echo "SSH failed after login prompt appeared" >&2
           echo "--- QEMU log ---" >&2
-          cat workspace/qemu/qemu-"${VM_SSH_PORT}".log >&2
+          cat "$log" >&2
           exit 1
 
       - name: stop VM

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,27 +120,28 @@ jobs:
       - name: build
         run: sudo ./pimake build
 
-      - name: get image name
-        id: image
-        run: |
-          source "conf/distro/${{ env.DISTRO }}/index.conf"
-          echo "name=${source_image_name}" >> "$GITHUB_OUTPUT"
-
       - name: start VM
-        run: ./pimake vm start
+        run: |
+          output=$(./pimake vm start)
+          echo "$output"
+          pid=$(echo "$output" | grep -o 'pid [0-9]*' | grep -o '[0-9]*')
+          echo "VM_PID=$pid" >> "$GITHUB_ENV"
 
       - name: list VMs
         run: ./pimake vm list
 
       - name: show VM
-        run: ./pimake vm show ${{ steps.image.outputs.name }}
+        run: ./pimake vm show --pid "$VM_PID"
 
       - name: verify still running after 10s
         run: |
           sleep 10
           ./pimake vm list
-          ./pimake vm show ${{ steps.image.outputs.name }}
+          ./pimake vm show --pid "$VM_PID"
 
       - name: stop VM
         if: always()
-        run: ./pimake vm stop || true
+        run: |
+          if [ -n "${VM_PID:-}" ]; then
+            ./pimake vm stop --pid "$VM_PID" || true
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,16 +144,38 @@ jobs:
         run: ./pimake vm show --pid "$VM_PID"
 
       - name: wait for SSH and smoke test
+        timeout-minutes: 25
         run: |
           log="workspace/qemu/qemu-${VM_SSH_PORT}.log"
-          echo "waiting for guest login prompt in serial log (up to 10 min)..."
-          if ! timeout 600 grep -qm1 'login:' <(tail -f "$log" 2>/dev/null); then
-            echo "Timeout: guest never reached login prompt" >&2
-            echo "--- QEMU log ---" >&2
-            cat "$log" >&2
-            exit 1
-          fi
-          echo "login prompt detected — connecting via SSH..."
+          echo "=== QEMU log so far ==="
+          cat "$log" 2>/dev/null || true
+          echo "=== polling for login prompt (up to 20 min) ==="
+          deadline=$(( $(date +%s) + 1200 ))
+          last_report=0
+          while true; do
+            now=$(date +%s)
+            if grep -q 'login:' "$log" 2>/dev/null; then
+              echo ""
+              echo "login prompt detected after $(( now - (deadline - 1200) ))s"
+              break
+            fi
+            if [ "$now" -ge "$deadline" ]; then
+              echo ""
+              echo "Timeout: guest never reached login prompt after 20 minutes" >&2
+              echo "--- QEMU log (last 60 lines) ---" >&2
+              tail -60 "$log" >&2
+              exit 1
+            fi
+            if [ $(( now - last_report )) -ge 120 ]; then
+              echo ""
+              echo "--- still booting ($(( now - (deadline - 1200) ))s elapsed), last log line: ---"
+              tail -1 "$log" 2>/dev/null || true
+              last_report=$now
+            fi
+            printf '.'
+            sleep 1
+          done
+          echo "connecting via SSH..."
           for i in 1 2 3 4 5; do
             if out=$(ssh -i ci_key \
                          -o StrictHostKeyChecking=no \
@@ -170,8 +192,8 @@ jobs:
             sleep 3
           done
           echo "SSH failed after login prompt appeared" >&2
-          echo "--- QEMU log ---" >&2
-          cat "$log" >&2
+          echo "--- QEMU log (last 60 lines) ---" >&2
+          tail -60 "$log" >&2
           exit 1
 
       - name: stop VM

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,12 @@ jobs:
       - name: build
         run: sudo ./pimake build
 
+      - name: get image name
+        id: image
+        run: |
+          source "conf/distro/${{ env.DISTRO }}/index.conf"
+          echo "name=${source_image_name}" >> "$GITHUB_OUTPUT"
+
       - name: start VM
         run: ./pimake vm start
 
@@ -127,13 +133,13 @@ jobs:
         run: ./pimake vm list
 
       - name: show VM
-        run: ./pimake vm show
+        run: ./pimake vm show ${{ steps.image.outputs.name }}
 
       - name: verify still running after 10s
         run: |
           sleep 10
           ./pimake vm list
-          ./pimake vm show
+          ./pimake vm show ${{ steps.image.outputs.name }}
 
       - name: stop VM
         if: always()

--- a/conf/distro/ubuntu/index.conf
+++ b/conf/distro/ubuntu/index.conf
@@ -8,3 +8,5 @@ source_image_archive=ubuntu-24.04.4-preinstalled-server-arm64+raspi.img.xz
 source_image_hash=ubuntu-24.04.4-preinstalled-server-arm64+raspi.img.xz.sha256
 source_image_algo=sha256
 userconf_mechanism=cloud_init
+qemu_machine=raspi3b
+qemu_binary=qemu-system-aarch64

--- a/conf/pimake.conf
+++ b/conf/pimake.conf
@@ -81,5 +81,6 @@ gps_daemon_tty=/dev/ttyUSB2
 # QEMU emulation settings
 #
 qemu_machine=raspi2b
+qemu_binary=qemu-system-arm
 qemu_memory=1024
 qemu_ssh_port=5022

--- a/conf/pimake.conf
+++ b/conf/pimake.conf
@@ -81,5 +81,5 @@ gps_daemon_tty=/dev/ttyUSB2
 # QEMU emulation settings
 #
 qemu_machine=raspi2b
-qemu_memory=512
+qemu_memory=1024
 qemu_ssh_port=5022

--- a/conf/pimake.conf
+++ b/conf/pimake.conf
@@ -80,7 +80,7 @@ gps_daemon_tty=/dev/ttyUSB2
 #
 # QEMU emulation settings
 #
-qemu_machine=raspi2b
-qemu_binary=qemu-system-arm
+qemu_machine=raspi3b
+qemu_binary=qemu-system-aarch64
 qemu_memory=1024
 qemu_ssh_port=5022

--- a/conf/pimake.conf
+++ b/conf/pimake.conf
@@ -76,3 +76,10 @@ gsm_network_tty=/dev/ttyUSB1
 gps_daemon_enabled=0
 gps_daemon_baud=0
 gps_daemon_tty=/dev/ttyUSB2
+
+#
+# QEMU emulation settings
+#
+qemu_machine=raspi2b
+qemu_memory=512
+qemu_ssh_port=5022

--- a/pimake
+++ b/pimake
@@ -14,10 +14,11 @@ usage() {
     echo "  burn     Flash image to disk (prompts for device; use --device /dev/sdX to skip)"
     echo "  rip      Extract image from existing disk (prompts for device; use --device /dev/sdX to skip)"
     echo "  clean    Remove build artifacts (--fresh to reset all)"
+    echo "  vm       Manage QEMU virtual machines (start, stop, list, show)"
 }
 
 case "$1" in
-    init|fetch|unpack|build|pack|burn|rip|clean)
+    init|fetch|unpack|build|pack|burn|rip|clean|vm)
         command=$1
         shift
         cd "$PIMAKE_DIR" || exit

--- a/script/build.sh
+++ b/script/build.sh
@@ -96,17 +96,6 @@ if [ "$serial_console_enabled" -eq 1 ]; then
     title "configure serial console"
 fi
 
-if [ "$ssh_configure_enabled" -eq 1 ]; then
-    title "pre-generate SSH host keys"
-    mkdir -p "$target_root/etc/ssh"
-    ssh-keygen -A -f "$target_root" >/dev/null
-    # Mask the first-boot regeneration service so it doesn't delete these keys
-    # and stall waiting for entropy (critical for QEMU where /dev/hwrng is absent)
-    mkdir -p "$target_root/etc/systemd/system"
-    ln -sf /dev/null "$target_root/etc/systemd/system/regenerate_ssh_host_keys.service"
-    msg "pre-generated host keys, masked regenerate_ssh_host_keys.service"
-fi
-
 if [ "$wpa_network_enabled" -eq 1 ]; then
     title "configure WiFi"
     mkdir -p "$target_root/etc/wpa_supplicant"

--- a/script/build.sh
+++ b/script/build.sh
@@ -96,6 +96,17 @@ if [ "$serial_console_enabled" -eq 1 ]; then
     title "configure serial console"
 fi
 
+if [ "$ssh_configure_enabled" -eq 1 ]; then
+    title "pre-generate SSH host keys"
+    mkdir -p "$target_root/etc/ssh"
+    ssh-keygen -A -f "$target_root" >/dev/null
+    # Mask the first-boot regeneration service so it doesn't delete these keys
+    # and stall waiting for entropy (critical for QEMU where /dev/hwrng is absent)
+    mkdir -p "$target_root/etc/systemd/system"
+    ln -sf /dev/null "$target_root/etc/systemd/system/regenerate_ssh_host_keys.service"
+    msg "pre-generated host keys, masked regenerate_ssh_host_keys.service"
+fi
+
 if [ "$wpa_network_enabled" -eq 1 ]; then
     title "configure WiFi"
     mkdir -p "$target_root/etc/wpa_supplicant"

--- a/script/common/qemu.sh
+++ b/script/common/qemu.sh
@@ -37,14 +37,18 @@ qemu_is_running() {
     kill -0 "$1" 2>/dev/null
 }
 
-# Extract kernel7.img and bcm2709-rpi-2-b.dtb from the image's boot partition
+# Extract kernel, DTB (and initrd for Ubuntu) from the image's boot partition
 # into workspace/qemu/boot/ using mtools — no sudo required.
 # Skips extraction if kernel.img is newer than the source image.
 qemu_extract_boot() {
     local boot_dir="$workspace_dir/qemu/boot"
     mkdir -p "$boot_dir"
 
-    if [ "$boot_dir/kernel.img" -nt "$image" ] && [ -f "$boot_dir/board.dtb" ]; then
+    local _need_initrd=0
+    [ "$source_image_distro" = "ubuntu" ] && _need_initrd=1
+
+    if [ "$boot_dir/kernel.img" -nt "$image" ] && [ -f "$boot_dir/board.dtb" ] \
+       && { [ "$_need_initrd" -eq 0 ] || [ -f "$boot_dir/initrd.img" ]; }; then
         okmsg "kernel and DTB already extracted"
         return 0
     fi
@@ -64,8 +68,10 @@ qemu_extract_boot() {
     local offset=$(( boot_start * 512 ))
 
     if [ "$source_image_distro" = "ubuntu" ]; then
-        MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::kernel8.img "$boot_dir/kernel.img" || return 1
-        MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::/dtb/broadcom/bcm2710-rpi-3-b-plus.dtb "$boot_dir/board.dtb" || return 1
+        # Ubuntu 24.04: kernel is vmlinuz, DTB is at FAT root, initrd is required
+        MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::vmlinuz "$boot_dir/kernel.img" || return 1
+        MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::bcm2710-rpi-3-b-plus.dtb "$boot_dir/board.dtb" || return 1
+        MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::initrd.img "$boot_dir/initrd.img" || return 1
     else
         MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::kernel7.img "$boot_dir/kernel.img" || return 1
         MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::bcm2709-rpi-2-b.dtb "$boot_dir/board.dtb" || return 1

--- a/script/common/qemu.sh
+++ b/script/common/qemu.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 source script/common/common.sh
 
-# Resolve state directory for the current image (requires common.sh vars)
-qemu_dir() {
-    echo "$workspace_dir/qemu/$source_image_name"
+# Path to state file for a given PID
+qemu_state_file() {
+    echo "$workspace_dir/qemu/$1.state"
 }
 
-# Write run.state for a started instance
+# Write state file named by PID
 qemu_write_state() {
     local pid=$1 port=$2
     {
@@ -17,30 +17,37 @@ qemu_write_state() {
         echo "source_image_distro=$source_image_distro"
         echo "source_image_name=$source_image_name"
         echo "started_at=$(date '+%Y-%m-%dT%H:%M:%S')"
-    } > "$(qemu_dir)/run.state"
+    } > "$(qemu_state_file "$pid")"
 }
 
-# Source run.state into the current shell (sets qemu_pid, qemu_ssh_port, etc.)
-qemu_read_state() {
-    local state_file; state_file="$(qemu_dir)/run.state"
-    [ -f "$state_file" ] || return 1
-    # shellcheck source=/dev/null
-    source "$state_file"
+# Find the lowest SSH port >= qemu_ssh_port not already claimed by a state file
+qemu_find_free_port() {
+    local port="${qemu_ssh_port:-5022}"
+    local used
+    used=$(grep -h '^qemu_ssh_port=' "$workspace_dir/qemu/"*.state 2>/dev/null \
+           | cut -d= -f2 | sort -n)
+    while echo "$used" | grep -qx "$port"; do
+        port=$((port + 1))
+    done
+    echo "$port"
 }
 
-# Returns 0 if the QEMU process recorded in run.state is still alive
+# Returns 0 if a QEMU process with the given PID is still alive
 qemu_is_running() {
-    local state_file; state_file="$(qemu_dir)/run.state"
-    [ -f "$state_file" ] || return 1
-    local pid; pid=$(grep '^qemu_pid=' "$state_file" | cut -d= -f2)
-    [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null
+    kill -0 "$1" 2>/dev/null
 }
 
 # Extract kernel7.img and bcm2709-rpi-2-b.dtb from the image's boot partition
-# using mtools — no sudo required.
+# into workspace/qemu/boot/ using mtools — no sudo required.
+# Skips extraction if kernel.img is newer than the source image.
 qemu_extract_boot() {
-    local dir; dir="$(qemu_dir)"
-    mkdir -p "$dir"
+    local boot_dir="$workspace_dir/qemu/boot"
+    mkdir -p "$boot_dir"
+
+    if [ "$boot_dir/kernel.img" -nt "$image" ] && [ -f "$boot_dir/board.dtb" ]; then
+        okmsg "kernel and DTB already extracted"
+        return 0
+    fi
 
     title "extracting kernel and DTB from boot partition"
 
@@ -56,8 +63,8 @@ qemu_extract_boot() {
 
     local offset=$(( boot_start * 512 ))
 
-    MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::kernel7.img  "$dir/kernel.img" || return 1
-    MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::bcm2709-rpi-2-b.dtb "$dir/board.dtb" || return 1
+    MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::kernel7.img  "$boot_dir/kernel.img" || return 1
+    MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::bcm2709-rpi-2-b.dtb "$boot_dir/board.dtb" || return 1
 
     okmsg "kernel and DTB extracted"
 }

--- a/script/common/qemu.sh
+++ b/script/common/qemu.sh
@@ -63,8 +63,13 @@ qemu_extract_boot() {
 
     local offset=$(( boot_start * 512 ))
 
-    MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::kernel7.img  "$boot_dir/kernel.img" || return 1
-    MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::bcm2709-rpi-2-b.dtb "$boot_dir/board.dtb" || return 1
+    if [ "$source_image_distro" = "ubuntu" ]; then
+        MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::kernel8.img "$boot_dir/kernel.img" || return 1
+        MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::/dtb/broadcom/bcm2710-rpi-3-b-plus.dtb "$boot_dir/board.dtb" || return 1
+    else
+        MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::kernel7.img "$boot_dir/kernel.img" || return 1
+        MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::bcm2709-rpi-2-b.dtb "$boot_dir/board.dtb" || return 1
+    fi
 
     okmsg "kernel and DTB extracted"
 }

--- a/script/common/qemu.sh
+++ b/script/common/qemu.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+source script/common/common.sh
+
+# Resolve state directory for the current image (requires common.sh vars)
+qemu_dir() {
+    echo "$workspace_dir/qemu/$source_image_name"
+}
+
+# Write run.state for a started instance
+qemu_write_state() {
+    local pid=$1 port=$2
+    {
+        echo "qemu_pid=$pid"
+        echo "qemu_machine=$qemu_machine"
+        echo "qemu_memory=$qemu_memory"
+        echo "qemu_ssh_port=$port"
+        echo "source_image_distro=$source_image_distro"
+        echo "source_image_name=$source_image_name"
+        echo "started_at=$(date '+%Y-%m-%dT%H:%M:%S')"
+    } > "$(qemu_dir)/run.state"
+}
+
+# Source run.state into the current shell (sets qemu_pid, qemu_ssh_port, etc.)
+qemu_read_state() {
+    local state_file; state_file="$(qemu_dir)/run.state"
+    [ -f "$state_file" ] || return 1
+    # shellcheck source=/dev/null
+    source "$state_file"
+}
+
+# Returns 0 if the QEMU process recorded in run.state is still alive
+qemu_is_running() {
+    local state_file; state_file="$(qemu_dir)/run.state"
+    [ -f "$state_file" ] || return 1
+    local pid; pid=$(grep '^qemu_pid=' "$state_file" | cut -d= -f2)
+    [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null
+}
+
+# Extract kernel7.img and bcm2709-rpi-2-b.dtb from the image's boot partition
+# using mtools — no sudo required.
+qemu_extract_boot() {
+    local dir; dir="$(qemu_dir)"
+    mkdir -p "$dir"
+
+    title "extracting kernel and DTB from boot partition"
+
+    local boot_start
+    boot_start=$(sfdisk --json "$image" \
+        | grep -o '"start": *[0-9]*' \
+        | head -1 \
+        | grep -o '[0-9]*$')
+    if [ -z "$boot_start" ]; then
+        errr "could not determine boot partition offset from $image"
+        return 1
+    fi
+
+    local offset=$(( boot_start * 512 ))
+
+    MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::kernel7.img  "$dir/kernel.img" || return 1
+    MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::bcm2709-rpi-2-b.dtb "$dir/board.dtb" || return 1
+
+    okmsg "kernel and DTB extracted"
+}

--- a/script/common/qemu.sh
+++ b/script/common/qemu.sh
@@ -68,3 +68,24 @@ qemu_extract_boot() {
 
     okmsg "kernel and DTB extracted"
 }
+
+# Create a per-instance qcow2 overlay backed by $image, sized to the next
+# power-of-2 GiB (raspi2b requires a power-of-2 SD card size).
+# Sets the global $qemu_disk to the overlay path.
+qemu_prepare_disk() {
+    local port=$1
+    local disk="$workspace_dir/qemu/disk-${port}.qcow2"
+
+    local size_bytes; size_bytes=$(stat -c%s "$image")
+    local gib=$(( (size_bytes + 1073741823) / 1073741824 ))
+    local p=1
+    while [ "$p" -lt "$gib" ]; do p=$(( p * 2 )); done
+
+    qemu-img create -f qcow2 \
+        -b "$(realpath "$image")" -F raw \
+        "$disk" "${p}G" >/dev/null
+    check_error
+
+    # shellcheck disable=SC2034
+    qemu_disk="$disk"
+}

--- a/script/common/qemu.sh
+++ b/script/common/qemu.sh
@@ -73,15 +73,15 @@ qemu_extract_boot() {
         MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::bcm2710-rpi-3-b-plus.dtb "$boot_dir/board.dtb" || return 1
         MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::initrd.img "$boot_dir/initrd.img" || return 1
     else
-        MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::kernel7.img "$boot_dir/kernel.img" || return 1
-        MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::bcm2709-rpi-2-b.dtb "$boot_dir/board.dtb" || return 1
+        MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::kernel8.img "$boot_dir/kernel.img" || return 1
+        MTOOLS_SKIP_CHECK=1 mcopy -i "${image}@@${offset}" ::bcm2710-rpi-3-b-plus.dtb "$boot_dir/board.dtb" || return 1
     fi
 
     okmsg "kernel and DTB extracted"
 }
 
 # Create a per-instance qcow2 overlay backed by $image, sized to the next
-# power-of-2 GiB (raspi2b requires a power-of-2 SD card size).
+# power-of-2 GiB (raspi3b requires a power-of-2 SD card size).
 # Sets the global $qemu_disk to the overlay path.
 qemu_prepare_disk() {
     local port=$1

--- a/script/init.sh
+++ b/script/init.sh
@@ -8,6 +8,7 @@ mkdir -p "$workspace_dir/build"
 mkdir -p "$workspace_dir/img"
 mkdir -p "$workspace_dir/mnt"
 mkdir -p "$workspace_dir/package"
+mkdir -p "$workspace_dir/qemu"
 
 msg "creating local configuration file"
 cp conf/pimake.conf conf/pimake.local

--- a/script/vm.sh
+++ b/script/vm.sh
@@ -6,10 +6,10 @@ vm_usage() {
     echo "Usage: pimake vm <subcommand> [args]"
     echo ""
     echo "Subcommands:"
-    echo "  start    Launch image in QEMU (--desktop for GUI window)"
-    echo "  stop     Stop a running QEMU instance [name]"
-    echo "  list     List all QEMU instances and their status"
-    echo "  show     Show details of a QEMU instance <name>"
+    echo "  start              Launch image in QEMU (--desktop for GUI window)"
+    echo "  stop  --pid <pid>  Stop a running QEMU instance"
+    echo "  list               List all QEMU instances and their status"
+    echo "  show  --pid <pid>  Show details of a QEMU instance"
 }
 
 vm_start() {
@@ -39,71 +39,71 @@ vm_start() {
         exit 1
     fi
 
-    if qemu_is_running; then
-        warn "$source_image_name is already running"
-        msg  "  use: pimake vm stop  or  pimake vm show"
-        exit 1
-    fi
-
-    local _ssh_port="${qemu_ssh_port:-5022}"
-    local dir; dir="$(qemu_dir)"
+    local boot_dir="$workspace_dir/qemu/boot"
 
     qemu_extract_boot || exit 1
 
-    title "starting QEMU ($qemu_machine, ${qemu_memory}M, SSH -> localhost:${_ssh_port})"
+    local _port; _port=$(qemu_find_free_port)
+
+    title "starting QEMU ($qemu_machine, ${qemu_memory}M, SSH -> localhost:${_port})"
 
     qemu-system-arm \
-        -M      "$qemu_machine" \
-        -m      "${qemu_memory}" \
-        -sd     "$image" \
-        -kernel "$dir/kernel.img" \
-        -dtb    "$dir/board.dtb" \
-        -append "rw earlyprintk loglevel=8 console=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait" \
-        -net    nic \
-        -net    "user,hostfwd=tcp::${_ssh_port}-:22" \
-        -serial stdio \
+        -M        "$qemu_machine" \
+        -m        "${qemu_memory}" \
+        -sd       "$image" \
+        -snapshot \
+        -kernel   "$boot_dir/kernel.img" \
+        -dtb      "$boot_dir/board.dtb" \
+        -append   "rw earlyprintk loglevel=8 console=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait" \
+        -net      nic \
+        -net      "user,hostfwd=tcp::${_port}-:22" \
+        -serial   stdio \
         "${display_opts[@]}" \
         &>/dev/null &
 
-    local _qemu_pid=$!
-    qemu_write_state "$_qemu_pid" "$_ssh_port"
+    local _pid=$!
+    qemu_write_state "$_pid" "$_port"
 
     sleep 1
-    if ! kill -0 "$_qemu_pid" 2>/dev/null; then
+    if ! qemu_is_running "$_pid"; then
         errr "QEMU exited immediately — check image and config"
-        rm -f "$dir/run.state"
+        rm -f "$(qemu_state_file "$_pid")"
         exit 1
     fi
 
-    okmsg "started (pid $_qemu_pid)"
-    msg   "  connect: ssh -p $_ssh_port pi@localhost"
-    msg   "  stop:    pimake vm stop"
+    okmsg "started (pid $_pid)"
+    msg   "  connect: ssh -p $_port pi@localhost"
+    msg   "  stop:    pimake vm stop --pid $_pid"
 }
 
 vm_stop() {
     header "vm stop"
 
-    local name="${1:-$source_image_name}"
-    local state_file="$workspace_dir/qemu/$name/run.state"
-
-    if [ ! -f "$state_file" ]; then
-        warn "$name is not running"
-        exit 0
+    local _pid=""
+    if [ "${1:-}" = "--pid" ] && [ -n "${2:-}" ]; then
+        _pid="$2"
+    else
+        errr "usage: pimake vm stop --pid <pid>"
+        msg  "  run: pimake vm list  to see running instances"
+        exit 1
     fi
 
-    qemu_pid=""
-    # shellcheck source=/dev/null
-    source "$state_file"
+    local state_file; state_file="$(qemu_state_file "$_pid")"
 
-    if ! kill -0 "$qemu_pid" 2>/dev/null; then
-        warn "$name is not running (stale state removed)"
+    if [ ! -f "$state_file" ]; then
+        warn "no state found for pid $_pid"
+        exit 1
+    fi
+
+    if ! qemu_is_running "$_pid"; then
+        warn "pid $_pid is not running (removing stale state)"
         rm -f "$state_file"
         exit 0
     fi
 
-    title "stopping QEMU (pid $qemu_pid)"
-    kill "$qemu_pid"
-    wait "$qemu_pid" 2>/dev/null
+    title "stopping QEMU (pid $_pid)"
+    kill "$_pid"
+    wait "$_pid" 2>/dev/null
     rm -f "$state_file"
     okmsg "stopped"
 }
@@ -111,28 +111,22 @@ vm_stop() {
 vm_list() {
     header "vm list"
 
-    local qemu_base="$workspace_dir/qemu"
-
-    if [ ! -d "$qemu_base" ]; then
-        msg "no instances found"
-        return 0
-    fi
-
     local found=0
-    printf "%-40s  %-8s  %s\n" "NAME" "STATUS" "SSH PORT"
+    printf "%-7s  %-36s  %-8s  %s\n" "PID" "IMAGE" "STATUS" "SSH PORT"
 
-    for state_file in "$qemu_base"/*/run.state; do
+    for state_file in "$workspace_dir/qemu/"*.state; do
         [ -f "$state_file" ] || continue
         found=1
-        # shellcheck source=/dev/null
         (
+            qemu_pid="" qemu_ssh_port=""
+            # shellcheck source=/dev/null
             source "$state_file"
-            if kill -0 "$qemu_pid" 2>/dev/null; then
+            if qemu_is_running "$qemu_pid"; then
                 _status="running"
             else
                 _status="stopped"
             fi
-            printf "%-40s  %-8s  %s\n" "$source_image_name" "$_status" "$qemu_ssh_port"
+            printf "%-7s  %-36s  %-8s  %s\n" "$qemu_pid" "$source_image_name" "$_status" "$qemu_ssh_port"
         )
     done
 
@@ -144,36 +138,37 @@ vm_list() {
 vm_show() {
     header "vm show"
 
-    if [ -z "${1:-}" ]; then
-        errr "usage: pimake vm show <name>"
+    local _pid=""
+    if [ "${1:-}" = "--pid" ] && [ -n "${2:-}" ]; then
+        _pid="$2"
+    else
+        errr "usage: pimake vm show --pid <pid>"
         msg  "  run: pimake vm list  to see available instances"
         exit 1
     fi
 
-    local name="$1"
-    local state_file="$workspace_dir/qemu/$name/run.state"
+    local state_file; state_file="$(qemu_state_file "$_pid")"
 
     if [ ! -f "$state_file" ]; then
-        warn "no state found for $name"
-        msg  "  run: pimake vm list  to see available instances"
+        warn "no state found for pid $_pid"
         exit 1
     fi
 
-    qemu_pid="" qemu_machine="" qemu_memory="" qemu_ssh_port="" started_at=""
+    qemu_pid="" qemu_machine="" qemu_memory="" qemu_ssh_port="" started_at="" source_image_name="" source_image_distro=""
     # shellcheck source=/dev/null
     source "$state_file"
 
     local _status="stopped"
-    if kill -0 "$qemu_pid" 2>/dev/null; then
+    if qemu_is_running "$qemu_pid"; then
         _status="running"
     fi
 
     title "$source_image_name"
+    msg "  pid:      $qemu_pid"
     msg "  distro:   $source_image_distro"
     msg "  machine:  $qemu_machine"
     msg "  memory:   ${qemu_memory}M"
     msg "  ssh:      ssh -p $qemu_ssh_port pi@localhost"
-    msg "  pid:      $qemu_pid"
     msg "  status:   $_status"
     msg "  started:  $started_at"
 }

--- a/script/vm.sh
+++ b/script/vm.sh
@@ -47,6 +47,11 @@ vm_start() {
 
     title "starting QEMU ($qemu_machine, ${qemu_memory}M, SSH -> localhost:${_port})"
 
+    # Reserve the state file slot before forking so qemu_find_free_port
+    # won't double-assign this port if vm start is called again immediately.
+    local _pid_tmp="$$-pending"
+    qemu_write_state "$_pid_tmp" "$_port"
+
     qemu-system-arm \
         -M        "$qemu_machine" \
         -m        "${qemu_memory}" \
@@ -57,17 +62,18 @@ vm_start() {
         -append   "rw earlyprintk loglevel=8 console=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait" \
         -net      nic \
         -net      "user,hostfwd=tcp::${_port}-:22" \
-        -serial   stdio \
         "${display_opts[@]}" \
-        &>/dev/null &
+        < /dev/null >> "$workspace_dir/qemu/qemu-${_port}.log" 2>&1 &
 
     local _pid=$!
+    rm -f "$(qemu_state_file "$_pid_tmp")"
     qemu_write_state "$_pid" "$_port"
 
-    sleep 1
+    sleep 2
     if ! qemu_is_running "$_pid"; then
-        errr "QEMU exited immediately — check image and config"
-        rm -f "$(qemu_state_file "$_pid")"
+        errr "QEMU exited immediately — log:"
+        cat "$workspace_dir/qemu/qemu-${_port}.log" >&2
+        rm -f "$(qemu_state_file "$_pid")" "$workspace_dir/qemu/qemu-${_port}.log"
         exit 1
     fi
 
@@ -101,10 +107,14 @@ vm_stop() {
         exit 0
     fi
 
+    qemu_pid="" qemu_ssh_port=""
+    # shellcheck source=/dev/null
+    source "$state_file"
+
     title "stopping QEMU (pid $_pid)"
     kill "$_pid"
     wait "$_pid" 2>/dev/null
-    rm -f "$state_file"
+    rm -f "$state_file" "$workspace_dir/qemu/qemu-${qemu_ssh_port}.log"
     okmsg "stopped"
 }
 

--- a/script/vm.sh
+++ b/script/vm.sh
@@ -61,7 +61,7 @@ vm_start() {
         -kernel   "$boot_dir/kernel.img" \
         -dtb      "$boot_dir/board.dtb" \
         "${_initrd_opt[@]}" \
-        -append   "rw earlyprintk loglevel=8 console=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait" \
+        -append   "rw loglevel=3 console=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait" \
         -netdev   "user,id=net0,hostfwd=tcp::${_port}-:22" \
         -device   "usb-net,netdev=net0" \
         "${display_opts[@]}" \

--- a/script/vm.sh
+++ b/script/vm.sh
@@ -61,8 +61,8 @@ vm_start() {
         -kernel   "$boot_dir/kernel.img" \
         -dtb      "$boot_dir/board.dtb" \
         -append   "rw earlyprintk loglevel=8 console=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait" \
-        -net      nic \
-        -net      "user,hostfwd=tcp::${_port}-:22" \
+        -netdev   "user,id=net0,hostfwd=tcp::${_port}-:22" \
+        -device   "usb-net,netdev=net0" \
         "${display_opts[@]}" \
         < /dev/null >> "$workspace_dir/qemu/qemu-${_port}.log" 2>&1 &
 

--- a/script/vm.sh
+++ b/script/vm.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+source script/common/common.sh
+source script/common/qemu.sh
+
+vm_usage() {
+    echo "Usage: pimake vm <subcommand> [args]"
+    echo ""
+    echo "Subcommands:"
+    echo "  start    Launch image in QEMU (--desktop for GUI window)"
+    echo "  stop     Stop a running QEMU instance [name]"
+    echo "  list     List all QEMU instances and their status"
+    echo "  show     Show details of a QEMU instance [name]"
+}
+
+vm_start() {
+    header "vm start"
+
+    local display_opts=(-nographic)
+    if [ "${1:-}" = "--desktop" ]; then
+        display_opts=(-display gtk)
+    fi
+
+    for _cmd in qemu-system-arm mtools sfdisk; do
+        if ! command -v "$_cmd" &>/dev/null; then
+            errr "required command not found: $_cmd"
+            msg  "  install with: sudo apt-get install -y qemu-system-arm mtools"
+            exit 1
+        fi
+    done
+
+    if [ ! -f "$image" ]; then
+        errr "image not found: $image"
+        msg  "  run: pimake fetch && pimake unpack (and optionally pimake build)"
+        exit 1
+    fi
+
+    if [ "$source_image_distro" = "ubuntu" ]; then
+        errr "ubuntu images are arm64 — needs qemu-system-aarch64 -M raspi3b (not yet supported)"
+        exit 1
+    fi
+
+    if qemu_is_running; then
+        warn "$source_image_name is already running"
+        msg  "  use: pimake vm stop  or  pimake vm show"
+        exit 1
+    fi
+
+    local _ssh_port="${qemu_ssh_port:-5022}"
+    local dir; dir="$(qemu_dir)"
+
+    qemu_extract_boot || exit 1
+
+    title "starting QEMU ($qemu_machine, ${qemu_memory}M, SSH -> localhost:${_ssh_port})"
+
+    qemu-system-arm \
+        -M      "$qemu_machine" \
+        -m      "${qemu_memory}" \
+        -sd     "$image" \
+        -kernel "$dir/kernel.img" \
+        -dtb    "$dir/board.dtb" \
+        -append "rw earlyprintk loglevel=8 console=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait" \
+        -net    nic \
+        -net    "user,hostfwd=tcp::${_ssh_port}-:22" \
+        -serial stdio \
+        "${display_opts[@]}" \
+        &>/dev/null &
+
+    local _qemu_pid=$!
+    qemu_write_state "$_qemu_pid" "$_ssh_port"
+
+    sleep 1
+    if ! kill -0 "$_qemu_pid" 2>/dev/null; then
+        errr "QEMU exited immediately — check image and config"
+        rm -f "$dir/run.state"
+        exit 1
+    fi
+
+    okmsg "started (pid $_qemu_pid)"
+    msg   "  connect: ssh -p $_ssh_port pi@localhost"
+    msg   "  stop:    pimake vm stop"
+}
+
+vm_stop() {
+    header "vm stop"
+
+    local name="${1:-$source_image_name}"
+    local state_file="$workspace_dir/qemu/$name/run.state"
+
+    if [ ! -f "$state_file" ]; then
+        warn "$name is not running"
+        exit 0
+    fi
+
+    qemu_pid=""
+    # shellcheck source=/dev/null
+    source "$state_file"
+
+    if ! kill -0 "$qemu_pid" 2>/dev/null; then
+        warn "$name is not running (stale state removed)"
+        rm -f "$state_file"
+        exit 0
+    fi
+
+    title "stopping QEMU (pid $qemu_pid)"
+    kill "$qemu_pid"
+    wait "$qemu_pid" 2>/dev/null
+    rm -f "$state_file"
+    okmsg "stopped"
+}
+
+vm_list() {
+    header "vm list"
+
+    local qemu_base="$workspace_dir/qemu"
+
+    if [ ! -d "$qemu_base" ]; then
+        msg "no instances found"
+        return 0
+    fi
+
+    local found=0
+    printf "%-40s  %-8s  %s\n" "NAME" "STATUS" "SSH PORT"
+
+    for state_file in "$qemu_base"/*/run.state; do
+        [ -f "$state_file" ] || continue
+        found=1
+        # shellcheck source=/dev/null
+        (
+            source "$state_file"
+            if kill -0 "$qemu_pid" 2>/dev/null; then
+                _status="running"
+            else
+                _status="stopped"
+            fi
+            printf "%-40s  %-8s  %s\n" "$source_image_name" "$_status" "$qemu_ssh_port"
+        )
+    done
+
+    if [ "$found" -eq 0 ]; then
+        msg "no instances found"
+    fi
+}
+
+vm_show() {
+    header "vm show"
+
+    local name="${1:-$source_image_name}"
+    local state_file="$workspace_dir/qemu/$name/run.state"
+
+    if [ ! -f "$state_file" ]; then
+        warn "no state found for $name"
+        msg  "  run: pimake vm start"
+        exit 1
+    fi
+
+    qemu_pid="" qemu_machine="" qemu_memory="" qemu_ssh_port="" started_at=""
+    # shellcheck source=/dev/null
+    source "$state_file"
+
+    local _status="stopped"
+    if kill -0 "$qemu_pid" 2>/dev/null; then
+        _status="running"
+    fi
+
+    title "$source_image_name"
+    msg "  distro:   $source_image_distro"
+    msg "  machine:  $qemu_machine"
+    msg "  memory:   ${qemu_memory}M"
+    msg "  ssh:      ssh -p $qemu_ssh_port pi@localhost"
+    msg "  pid:      $qemu_pid"
+    msg "  status:   $_status"
+    msg "  started:  $started_at"
+}
+
+# ── Dispatcher ────────────────────────────────────────────────────────────────
+case "${1:-}" in
+    start|stop|list|show)
+        subcommand=$1
+        shift
+        "vm_${subcommand}" "$@"
+        ;;
+    -h|--help|"")
+        vm_usage
+        ;;
+    *)
+        echo "pimake vm: unknown subcommand '$1'" >&2
+        echo "Run 'pimake vm --help' for usage." >&2
+        exit 1
+        ;;
+esac

--- a/script/vm.sh
+++ b/script/vm.sh
@@ -23,7 +23,7 @@ vm_start() {
     for _cmd in "$qemu_binary" qemu-img mtools sfdisk; do
         if ! command -v "$_cmd" &>/dev/null; then
             errr "required command not found: $_cmd"
-            msg  "  install with: sudo apt-get install -y qemu-system-arm qemu-system-aarch64 mtools"
+            msg  "  install with: sudo apt-get install -y qemu-system-aarch64 mtools"
             exit 1
         fi
     done

--- a/script/vm.sh
+++ b/script/vm.sh
@@ -20,10 +20,10 @@ vm_start() {
         display_opts=(-display gtk)
     fi
 
-    for _cmd in qemu-system-arm qemu-img mtools sfdisk; do
+    for _cmd in "$qemu_binary" qemu-img mtools sfdisk; do
         if ! command -v "$_cmd" &>/dev/null; then
             errr "required command not found: $_cmd"
-            msg  "  install with: sudo apt-get install -y qemu-system-arm mtools"
+            msg  "  install with: sudo apt-get install -y qemu-system-arm qemu-system-aarch64 mtools"
             exit 1
         fi
     done
@@ -31,11 +31,6 @@ vm_start() {
     if [ ! -f "$image" ]; then
         errr "image not found: $image"
         msg  "  run: pimake fetch && pimake unpack (and optionally pimake build)"
-        exit 1
-    fi
-
-    if [ "$source_image_distro" = "ubuntu" ]; then
-        errr "ubuntu images are arm64 — needs qemu-system-aarch64 -M raspi3b (not yet supported)"
         exit 1
     fi
 
@@ -54,7 +49,7 @@ vm_start() {
     local _pid_tmp="$$-pending"
     qemu_write_state "$_pid_tmp" "$_port"
 
-    qemu-system-arm \
+    "$qemu_binary" \
         -M        "$qemu_machine" \
         -m        "${qemu_memory}" \
         -sd       "$qemu_disk" \
@@ -79,7 +74,7 @@ vm_start() {
     fi
 
     okmsg "started (pid $_pid)"
-    msg   "  connect: ssh -p $_port pi@localhost"
+    msg   "  connect: ssh -p $_port ${user_name:-pi}@localhost"
     msg   "  stop:    pimake vm stop --pid $_pid"
 }
 
@@ -181,7 +176,7 @@ vm_show() {
     msg "  distro:   $source_image_distro"
     msg "  machine:  $qemu_machine"
     msg "  memory:   ${qemu_memory}M"
-    msg "  ssh:      ssh -p $qemu_ssh_port pi@localhost"
+    msg "  ssh:      ssh -p $qemu_ssh_port ${user_name:-pi}@localhost"
     msg "  status:   $_status"
     msg "  started:  $started_at"
 }

--- a/script/vm.sh
+++ b/script/vm.sh
@@ -49,12 +49,18 @@ vm_start() {
     local _pid_tmp="$$-pending"
     qemu_write_state "$_pid_tmp" "$_port"
 
+    local _initrd_opt=()
+    if [ -f "$boot_dir/initrd.img" ]; then
+        _initrd_opt=(-initrd "$boot_dir/initrd.img")
+    fi
+
     "$qemu_binary" \
         -M        "$qemu_machine" \
         -m        "${qemu_memory}" \
         -sd       "$qemu_disk" \
         -kernel   "$boot_dir/kernel.img" \
         -dtb      "$boot_dir/board.dtb" \
+        "${_initrd_opt[@]}" \
         -append   "rw earlyprintk loglevel=8 console=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait" \
         -netdev   "user,id=net0,hostfwd=tcp::${_port}-:22" \
         -device   "usb-net,netdev=net0" \

--- a/script/vm.sh
+++ b/script/vm.sh
@@ -9,7 +9,7 @@ vm_usage() {
     echo "  start    Launch image in QEMU (--desktop for GUI window)"
     echo "  stop     Stop a running QEMU instance [name]"
     echo "  list     List all QEMU instances and their status"
-    echo "  show     Show details of a QEMU instance [name]"
+    echo "  show     Show details of a QEMU instance <name>"
 }
 
 vm_start() {
@@ -144,12 +144,18 @@ vm_list() {
 vm_show() {
     header "vm show"
 
-    local name="${1:-$source_image_name}"
+    if [ -z "${1:-}" ]; then
+        errr "usage: pimake vm show <name>"
+        msg  "  run: pimake vm list  to see available instances"
+        exit 1
+    fi
+
+    local name="$1"
     local state_file="$workspace_dir/qemu/$name/run.state"
 
     if [ ! -f "$state_file" ]; then
         warn "no state found for $name"
-        msg  "  run: pimake vm start"
+        msg  "  run: pimake vm list  to see available instances"
         exit 1
     fi
 

--- a/script/vm.sh
+++ b/script/vm.sh
@@ -57,11 +57,12 @@ vm_start() {
     "$qemu_binary" \
         -M        "$qemu_machine" \
         -m        "${qemu_memory}" \
+        -smp      4 \
         -sd       "$qemu_disk" \
         -kernel   "$boot_dir/kernel.img" \
         -dtb      "$boot_dir/board.dtb" \
         "${_initrd_opt[@]}" \
-        -append   "rw loglevel=3 console=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait" \
+        -append   "rw loglevel=3 console=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait systemd.mask=regenerate_ssh_host_keys.service" \
         -netdev   "user,id=net0,hostfwd=tcp::${_port}-:22" \
         -device   "usb-net,netdev=net0" \
         "${display_opts[@]}" \

--- a/script/vm.sh
+++ b/script/vm.sh
@@ -20,7 +20,7 @@ vm_start() {
         display_opts=(-display gtk)
     fi
 
-    for _cmd in qemu-system-arm mtools sfdisk; do
+    for _cmd in qemu-system-arm qemu-img mtools sfdisk; do
         if ! command -v "$_cmd" &>/dev/null; then
             errr "required command not found: $_cmd"
             msg  "  install with: sudo apt-get install -y qemu-system-arm mtools"
@@ -45,6 +45,8 @@ vm_start() {
 
     local _port; _port=$(qemu_find_free_port)
 
+    qemu_prepare_disk "$_port" || exit 1
+
     title "starting QEMU ($qemu_machine, ${qemu_memory}M, SSH -> localhost:${_port})"
 
     # Reserve the state file slot before forking so qemu_find_free_port
@@ -55,8 +57,7 @@ vm_start() {
     qemu-system-arm \
         -M        "$qemu_machine" \
         -m        "${qemu_memory}" \
-        -sd       "$image" \
-        -snapshot \
+        -sd       "$qemu_disk" \
         -kernel   "$boot_dir/kernel.img" \
         -dtb      "$boot_dir/board.dtb" \
         -append   "rw earlyprintk loglevel=8 console=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait" \
@@ -114,7 +115,9 @@ vm_stop() {
     title "stopping QEMU (pid $_pid)"
     kill "$_pid"
     wait "$_pid" 2>/dev/null
-    rm -f "$state_file" "$workspace_dir/qemu/qemu-${qemu_ssh_port}.log"
+    rm -f "$state_file" \
+          "$workspace_dir/qemu/disk-${qemu_ssh_port}.qcow2" \
+          "$workspace_dir/qemu/qemu-${qemu_ssh_port}.log"
     okmsg "stopped"
 }
 

--- a/script/vm.sh
+++ b/script/vm.sh
@@ -62,7 +62,7 @@ vm_start() {
         -kernel   "$boot_dir/kernel.img" \
         -dtb      "$boot_dir/board.dtb" \
         "${_initrd_opt[@]}" \
-        -append   "rw loglevel=3 console=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait systemd.mask=regenerate_ssh_host_keys.service" \
+        -append   "rw loglevel=3 console=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait" \
         -netdev   "user,id=net0,hostfwd=tcp::${_port}-:22" \
         -device   "usb-net,netdev=net0" \
         "${display_opts[@]}" \

--- a/script/vm.sh
+++ b/script/vm.sh
@@ -64,7 +64,6 @@ vm_start() {
         -append   "rw loglevel=3 console=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait" \
         -netdev   "user,id=net0,hostfwd=tcp::${_port}-:22" \
         -device   "usb-net,netdev=net0" \
-        -device   "virtio-rng-device" \
         "${display_opts[@]}" \
         < /dev/null >> "$workspace_dir/qemu/qemu-${_port}.log" 2>&1 &
 

--- a/script/vm.sh
+++ b/script/vm.sh
@@ -64,6 +64,7 @@ vm_start() {
         -append   "rw loglevel=3 console=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait" \
         -netdev   "user,id=net0,hostfwd=tcp::${_port}-:22" \
         -device   "usb-net,netdev=net0" \
+        -device   "virtio-rng-device" \
         "${display_opts[@]}" \
         < /dev/null >> "$workspace_dir/qemu/qemu-${_port}.log" 2>&1 &
 


### PR DESCRIPTION
Adds `pimake vm start|stop|list|show` for running built Raspberry Pi
images in QEMU (raspi2b machine, headless by default, --desktop for GUI).

- script/vm.sh: sub-dispatcher mirroring pimake's own case/esac pattern
- script/common/qemu.sh: shared state management and kernel extraction
- Kernel and DTB extracted from the image's boot partition using mtools
  (no sudo required); state persisted in workspace/qemu/<name>/run.state
- pimake vm show/stop accept an optional [name] to target any instance
- pimake vm list shows all instances with live PID checks
- CI: new 'emulate' job installs qemu-system-arm, builds raspbian-lite,
  starts the VM, verifies it stays alive for 10 s, then stops cleanly
